### PR TITLE
fixes and singular timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ INCLUDE_DIRECTORIES(${ubox_include_dir} ${ubus_include_dir})
 FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(ubus NAMES ubus)
 
-SET(SOURCES main.c led.c ubus.c)
+SET(SOURCES main.c led.c ubus.c timer.c)
 SET(LIBS ${ubus} ${ubox})
 
 ADD_EXECUTABLE(uledd ${SOURCES})

--- a/led.c
+++ b/led.c
@@ -43,18 +43,24 @@ struct led {
 static void
 led_set(struct led *led, int brightness)
 {
+	int r;
 	FILE *fp;
 	char path[256];
 
-	led->current = brightness;
-	DEBUG(2, "set %s->%d\n", led->path, brightness);
+	DEBUG(3, "set %s to %d\n", led->path, brightness);
 
 	snprintf(path, sizeof(path), "/sys/class/leds/%s/brightness", led->path);
 	fp = fopen(path, "w");
 	if (!fp)
 		return;
-	fprintf(fp, "%d", brightness);
+
+	r = fprintf(fp, "%d", brightness);
 	fclose(fp);
+
+	if (r < 0)
+		return;
+
+	led->current = brightness;
 }
 
 static int

--- a/led.h
+++ b/led.h
@@ -6,4 +6,6 @@
 
 #pragma once
 
+void led_init();
+void led_done();
 void led_add(const char *path, int brightness, int original, int blink, int fade, int on, int off);

--- a/log.h
+++ b/log.h
@@ -12,7 +12,7 @@
 #ifdef ULEDD_DEBUG
 #define DEBUG(level, fmt, ...) do { \
 	if (debug >= level) { \
-		ulog(LOG_DEBUG, fmt, ## __VA_ARGS__); \
+		ulog(LOG_DEBUG, "%s: " fmt, __func__, ## __VA_ARGS__); \
 	} } while (0)
 #else
 #define DEBUG(level, fmt, ...)

--- a/main.c
+++ b/main.c
@@ -17,6 +17,8 @@
 unsigned int debug;
 #endif
 
+static char *ubus_socket = NULL;
+
 static int
 usage(const char *prog)
 {
@@ -25,6 +27,7 @@ usage(const char *prog)
 #ifdef ULEDD_DEBUG
 		"	-d <level>	Enable debug messages\n"
 #endif
+		"	-s <path>	Path to ubus socket\n"
 		"	-S		Print messages to stdout\n"
 		"\n", prog);
 	return 1;
@@ -43,13 +46,16 @@ int main(int argc, char **argv)
 	}
 #endif
 
-	while ((ch = getopt(argc, argv, "d:S")) != -1) {
+	while ((ch = getopt(argc, argv, "d:s:S")) != -1) {
 		switch (ch) {
 #ifdef ULEDD_DEBUG
 		case 'd':
 			debug = atoi(optarg);
 			break;
 #endif
+		case 's':
+			ubus_socket = optarg;
+			break;
 		case 'S':
 			ulog_channels = ULOG_STDIO;
 			break;
@@ -62,7 +68,7 @@ int main(int argc, char **argv)
 	LOG("v%s started.\n", ULEDD_VERSION);
 
 	uloop_init();
-	ubus_init();
+	ubus_init(ubus_socket);
 	uloop_run();
 	uloop_done();
 

--- a/main.c
+++ b/main.c
@@ -10,6 +10,7 @@
 
 #include <libubox/uloop.h>
 
+#include "led.h"
 #include "log.h"
 #include "ubus.h"
 
@@ -69,8 +70,12 @@ int main(int argc, char **argv)
 
 	uloop_init();
 	ubus_init(ubus_socket);
+	led_init();
+
 	uloop_run();
+
 	uloop_done();
+	led_done();
 
 	return 0;
 }

--- a/timer.c
+++ b/timer.c
@@ -1,0 +1,121 @@
+#include <time.h>
+#include <stdbool.h>
+
+#include <libubox/list.h>
+#include <libubox/uloop.h>
+
+#include "log.h"
+#include "timer.h"
+
+static int singular_timer_interval;
+static struct uloop_timeout singular_timer;
+static struct list_head timers = LIST_HEAD_INIT(timers);
+
+static int tv_diff(struct timeval *t1, struct timeval *t2)
+{
+	return
+		(t1->tv_sec - t2->tv_sec) * 1000 +
+		(t1->tv_usec - t2->tv_usec) / 1000;
+}
+
+static void led_timer_gettime(struct timeval *tv)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	tv->tv_sec = ts.tv_sec;
+	tv->tv_usec = ts.tv_nsec / 1000;
+}
+
+static void led_process_timers()
+{
+	struct timeval tv;
+	struct led_timer *t;
+
+	led_timer_gettime(&tv);
+
+	while (!list_empty(&timers)) {
+		t = list_first_entry(&timers, struct led_timer, list);
+
+		if (tv_diff(&t->time, &tv) > 0)
+			break;
+
+		led_timer_cancel(t);
+		if (t->cb)
+			t->cb(t);
+	}
+}
+
+static void singular_timer_cb(struct uloop_timeout *t)
+{
+	led_process_timers();
+	uloop_timeout_set(&singular_timer, singular_timer_interval);
+}
+
+int led_timer_add(struct led_timer *t)
+{
+	struct led_timer *tmp;
+	struct list_head *h = &timers;
+
+	if (t->pending)
+		return -1;
+
+	list_for_each_entry(tmp, &timers, list) {
+		if (tv_diff(&tmp->time, &t->time) > 0) {
+			h = &tmp->list;
+			break;
+		}
+	}
+
+	list_add_tail(&t->list, h);
+	t->pending = true;
+
+	return 0;
+}
+
+int led_timer_set(struct led_timer *t, int msecs)
+{
+	struct timeval *time = &t->time;
+
+	if (t->pending)
+		led_timer_cancel(t);
+
+	led_timer_gettime(time);
+
+	time->tv_sec += msecs / 1000;
+	time->tv_usec += (msecs % 1000) * 1000;
+
+	if (time->tv_usec > 1000000) {
+		time->tv_sec++;
+		time->tv_usec -= 1000000;
+	}
+
+	return led_timer_add(t);
+}
+
+int led_timer_cancel(struct led_timer *t)
+{
+	if (!t->pending)
+		return -1;
+
+	list_del(&t->list);
+	t->pending = false;
+
+	return 0;
+}
+
+void led_timers_init(int tick_interval)
+{
+	singular_timer.cb = singular_timer_cb;
+	singular_timer_interval = tick_interval;
+	uloop_timeout_set(&singular_timer, tick_interval);
+}
+
+void led_timers_done()
+{
+	struct led_timer *t, *tmp;
+
+	uloop_timeout_cancel(&singular_timer);
+	list_for_each_entry_safe(t, tmp, &timers, list)
+		led_timer_cancel(t);
+}

--- a/timer.h
+++ b/timer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+struct led_timer;
+typedef void (*led_timer_handler)(struct led_timer *t);
+
+struct led_timer {
+	bool pending;
+	led_timer_handler cb;
+	struct timeval time;
+	struct list_head list;
+};
+
+int led_timer_add(struct led_timer *t);
+int led_timer_set(struct led_timer *t, int msecs);
+int led_timer_cancel(struct led_timer *t);
+
+void led_timers_init(int tick_interval);
+void led_timers_done();

--- a/ubus.c
+++ b/ubus.c
@@ -100,8 +100,9 @@ ubus_connect_handler(struct ubus_context *ctx)
 }
 
 void
-ubus_init()
+ubus_init(const char *socket_path)
 {
+	conn.path = socket_path;
 	conn.cb = ubus_connect_handler;
 	ubus_auto_connect(&conn);
 }

--- a/ubus.h
+++ b/ubus.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-void ubus_init(void);
+void ubus_init(const char *socket_path);


### PR DESCRIPTION
83d4189606ca fix multiple timer drifts by using singular timer for all LEDs
3abe097ebecf log: output function name in debug log messages
5c768b337df8 led: set current brightness only after success
cf93720951bc allow overriding of default ubus socket path
b642b650a612 led: fix initial LED fading out