### PR TITLE
scene: Update all LEDs attached to a scene from the same timer handler

### DIFF
--- a/blob_led.c
+++ b/blob_led.c
@@ -34,6 +34,7 @@ blob_led_init(struct blob_led **b, const char *path, int brightness, int origina
 	n->blink = blink;
 	n->original = original;
 	n->brightness = brightness;
+	n->scene_led = 0;
 
 	n->path = strdup(path);
 	if (!n->path) {

--- a/blob_led.h
+++ b/blob_led.h
@@ -10,6 +10,7 @@ struct blob_led {
 	int on;
 	int off;
 	char *path;
+	int scene_led;
 };
 
 #define COLOUR_POLICY_LEN 5

--- a/led.h
+++ b/led.h
@@ -13,9 +13,10 @@ struct avl_tree;
 
 void led_init(int tick_interval);
 void led_done();
+int led_handle_timer(struct led *led);
 struct led *led_add(struct blob_led *b);
 struct led *led_from_path(const char *path);
-void led_run(struct led *led);
+int led_run(struct led *led);
 void led_stop(struct led *led);
 
 void leds_state_blobmsg(struct blob_buf *b);


### PR DESCRIPTION
On lower powered CPUs, when using the "blink" option for a scene with multiple LEDs, the different timers for each LED will slowly get out of sync. On an ipq40xx sitting idle, this can happen as quickly as after a couple minutes.  To address this, when LEDs are added as a part of a scene, use a timer for the scene as a whole, rather than for each individual LED.

Example use case: A trio of red/green/blue LEDs comes through the same light pipe, and is used for various statuses.  When trying to blink these three LEDs together, to provide a blinking white, the different colors will drift out of sync and provide noticeable points before and after the "white" period where individual colors are lit.